### PR TITLE
Change bot invite link permissons + link in server list

### DIFF
--- a/pages/templates/index.html
+++ b/pages/templates/index.html
@@ -92,7 +92,7 @@
             <br>
             <br>
             <a style="color: #647dcd;"
-              href='https://discordapp.com/oauth2/authorize?client_id=968999890640338955&scope=bot&permissions=8'>
+              href='https://discordapp.com/oauth2/authorize?client_id=968999890640338955&scope=bot&permissions=536870912'>
               <font face="Arial, Helvetica, sans-serif" color='#647dcd'>Add Discross to your server</font>
             </a>
             <br>

--- a/pages/templates/server/invalid_server.html
+++ b/pages/templates/server/invalid_server.html
@@ -1,6 +1,17 @@
-<font face="Arial, Helvetica, sans-serif" color="#dddddd">Click on a server <a href="/">
-        <font face="Arial, Helvetica, sans-serif" color="#dddddd">Home</font>
-    </a></font><br><a
-    href="https://discord.com/oauth2/authorize?client_id=968999890640338955&response_type=token&redirect_uri=https%3A%2F%2Fdiscross.rc24.xyz%2Fdiscord.html&scope=identify+guilds&prompt=none">
-    <font face="Arial, Helvetica, sans-serif" color="#dddddd">Click here to update your server list</font>
-</a>
+<font face="Arial, Helvetica, sans-serif" color="#dddddd">
+        Click on a server!
+        <br>
+        <a href="/">
+                <font face="Arial, Helvetica, sans-serif" color="#dddddd">Home</font>
+        </a>
+        </font>
+        <br>
+        <a 
+        href="https://discord.com/oauth2/authorize?client_id=968999890640338955&response_type=token&redirect_uri=https%3A%2F%2Fdiscross.rc24.xyz%2Fdiscord.html&scope=identify+guilds&prompt=none">
+            <font face="Arial, Helvetica, sans-serif" color="#dddddd">Click here to update your server list</font>
+        </a>
+        <br>
+        <a style="color: #647dcd;"
+        href='https://discordapp.com/oauth2/authorize?client_id=968999890640338955&scope=bot&permissions=536870912'>
+              <font face="Arial, Helvetica, sans-serif" color='#dddddd'>Add Discross to your server</font>
+        </a>


### PR DESCRIPTION
Change the required permissions from "Administrator" to "Manage Webhooks"
The only places with the invite link (before) are the home page and the Github README. I added it to the server list too for good measure

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Change the bot invite link permissions to 'Manage Webhooks' and add the invite link to the server list page for improved accessibility.

Enhancements:
- Update the bot invite link permissions from 'Administrator' to 'Manage Webhooks' to reduce required permissions.

Documentation:
- Add the bot invite link to the server list page for easier access.

<!-- Generated by sourcery-ai[bot]: end summary -->