### PR TITLE
 Fix typo + handle lack of permission better

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -26,11 +26,11 @@ client.on('messageCreate', async function (msg) {
 
   // console.log(msghistory[msg.channel.id.toString()].length);
   if (msg.content === '^connect') {
-    if (msg.webhookID) {
-      msg.reply("you're already using Discross!")
+    if (msg.webhookId) {
+      msg.reply("You're already using Discross!")
     } else {
       msg.author.send('Verification code:\n`' + (await auth.createVerificationCode(msg.author.id)) + '`')
-      msg.reply('you have been sent a direct message with your verification code.')
+      msg.reply('You have been sent a direct message with your verification code.')
     }
   }
 

--- a/pages/channel.js
+++ b/pages/channel.js
@@ -38,6 +38,7 @@ exports.processChannel = async function processChannel(bot, req, res, args, disc
     }
 
     if (chnl) {
+      botMember = await chnl.guild.members.fetch(bot.client.user.id)
       member = await chnl.guild.members.fetch(discordID);
       user = member.user;
       username = user.tag;
@@ -45,8 +46,8 @@ exports.processChannel = async function processChannel(bot, req, res, args, disc
         username = member.displayName + " (@" + user.tag + ")";
       }
 
-      if (!member.permissionsIn(chnl).has(PermissionFlagsBits.ViewChannel, true)) {
-        res.write("You don't have permission to do that!");
+      if (!member.permissionsIn(chnl).has(PermissionFlagsBits.ViewChannel, true) || !botMember.permissionsIn(chnl).has(PermissionFlagsBits.ViewChannel, true)) {
+        res.write("You (or the bot) don't have permission to do that!");
         res.end();
         return;
       }
@@ -170,7 +171,10 @@ exports.processChannel = async function processChannel(bot, req, res, args, disc
       const whiteThemeCookieValue = whiteThemeCookie?.split('=')[1]
       whiteThemeCookieValue == 1 ? template = strReplace(template, "{$WHITE_THEME_ENABLED}", "class=\"light-theme\"") : template = strReplace(template, "{$WHITE_THEME_ENABLED}", "")
 
-      if (member.permissionsIn(chnl).has(PermissionFlagsBits.SendMessages, true)) {
+      if (!botMember.permissionsIn(chnl).has(PermissionFlagsBits.ManageWebhooks, true)) {
+        final = strReplace(template, "{$INPUT}", input_disabled_template);
+        final = strReplace(final, "You don't have permission to send messages in this channel.", "Discross bot doesn't have the Manage Webhooks permission");
+      } else if (member.permissionsIn(chnl).has(PermissionFlagsBits.SendMessages, true)) {
         final = strReplace(template, "{$INPUT}", input_template);
       } else {
         final = strReplace(template, "{$INPUT}", input_disabled_template);
@@ -185,7 +189,8 @@ exports.processChannel = async function processChannel(bot, req, res, args, disc
       res.write("Invalid channel!"); //write a response to the client
       res.end(); //end the response
     }
-  } catch {
+  } catch (error) {
+    console.log(error)
     res.writeHead(302, { "Location": "/server/" });
     res.end();
   }

--- a/pages/templates/channel.html
+++ b/pages/templates/channel.html
@@ -139,13 +139,7 @@
                                             <div
                                                 style="box-sizing: border-box;-moz-box-sizing: border-box;-webkit-box-sizing: border-box;padding: 16px;background: #393c40;width: 100%;border-radius: 10px;">
                                                 {$INPUT}
-                                            </div>
-                                        </td>
-                                        <td style="width: 55px;">
-                                            <input type="submit"
-                                                style="width: 70px;right: 17px;position: relative;border-radius: 10px;border: transparent;color: #dddddd;height: 50px;background: #393c40;"
-                                                value="Send">
-                                        </td>
+
                                         <td valign="middle" style="vertical-align: middle; width: 48px;">
                                             <a href="{$REFRESH_URL}"><img src="/resources/images/refresh.gif"
                                                     alt="Refresh"></a>

--- a/pages/templates/channel/input.html
+++ b/pages/templates/channel/input.html
@@ -1,3 +1,10 @@
 <input type="text" name="message" id="message" value=""
     style="color: #dddddd;background: #393c40;border: none;width: 100%;outline: none;box-shadow: 0 0 0 50px #393c40 inset;-webkit-text-fill-color: #dddddd;"
     required="" placeholder="Message #general">
+</div>
+</td>
+<td style="width: 55px;">
+    <input type="submit"
+        style="width: 70px;right: 17px;position: relative;border-radius: 10px;border: transparent;color: #dddddd;height: 50px;background: #393c40;"
+        value="Send">
+</td>

--- a/pages/templates/channel/input_disabled.html
+++ b/pages/templates/channel/input_disabled.html
@@ -1,3 +1,5 @@
 <input type="text" name="message" id="message" value=""
     style="color: #dddddd;background: #393c40;border: none;width: 100%;outline: none;box-shadow: 0 0 0 50px #393c40 inset;-webkit-text-fill-color: #dddddd;"
     required="true" disabled="true" placeholder="You don't have permission to send messages in this channel.">
+</div>
+</td>


### PR DESCRIPTION
Before lack of "Manage Webhooks" permission error was handled like every other - it just dropped you at the server list. Now, you get a separate message if the bot doesn't have the "View Channel" or the "Manage Webhooks" permissions.
Also changed "webhookID" to "webhookId" to fix a typo and a bug that happened because of it

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance permission error handling by providing specific messages for missing 'View Channel' or 'Manage Webhooks' permissions and fix a typo in the variable name 'webhookID' to 'webhookId' to resolve a bug.

Bug Fixes:
- Fix typo in variable name from 'webhookID' to 'webhookId' to resolve a related bug.

Enhancements:
- Improve error handling by providing specific messages when the bot lacks 'View Channel' or 'Manage Webhooks' permissions.

<!-- Generated by sourcery-ai[bot]: end summary -->