### PR TITLE
Drawing Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,36 +10,39 @@ You can try out Discross there without having to invite the bot to your own serv
 ## Usage
 
 ### All of these steps have to be performed on a modern device that can access Discord.com
+
 0. Use the [link](https://discordapp.com/oauth2/authorize?client_id=968999890640338955&scope=bot&permissions=8) to add Discross to your server. Not necessary if you're already on a server with the bot.
 1. Type `^connect` on the server to get your verification code
 2. Go to [discross.rc24.xyz](https://discross.rc24.xyz/)
 3. Register on the website with that code
 4. Click the "update your server list" button to authorize Discross with your Discord account
+
 ### Now you can use Discross on all of your devices by logging into the account you have just made!
 
 ### Supported platforms
+
 Platforms that are confirmed to work, to some extent:
 
-* iPad
-* iPhone
-* Kindle
-* Nintendo 3DS
-* Nintendo DS
-* Nintendo DSi
-* Nintendo Switch
-* PlayStation 3
-* PlayStation 4
-* PlayStation 5
-* PlayStation Portable
-* PlayStation Vita
-* Sega Dreamcast
-* Wii Internet Channel
-* Wii U
-* Windows 95
-* Windows 98
-* Windows XP
-* Xbox 360
-* Xbox One
+- iPad
+- iPhone
+- Kindle
+- Nintendo 3DS
+- Nintendo DS
+- Nintendo DSi
+- Nintendo Switch
+- PlayStation 3
+- PlayStation 4
+- PlayStation 5
+- PlayStation Portable
+- PlayStation Vita
+- Sega Dreamcast
+- Wii Internet Channel
+- Wii U
+- Windows 95
+- Windows 98
+- Windows XP
+- Xbox 360
+- Xbox One
 
 ## Screenshots!
 
@@ -51,9 +54,9 @@ Platforms that are confirmed to work, to some extent:
 
 Make sure the following are installed:
 
-* Node.js
-* Python
-* Visual Studio Build Tools
+- Node.js
+- Python
+- Visual Studio Build Tools
 
 ```bash
 git clone https://github.com/larsenv/discross.git
@@ -101,7 +104,10 @@ Go to [localhost:4000](http://localhost:4000) and use it to register
 
 ### Discross is made by [circuit10](https://github.com/Heath123) (Heath123 is circuit10's GitHub username)
 
-
 ## Contributors
 
 - @koboshkobosh added the ability to reply to messages
+
+# Known Issues
+
+- On modern browsers, when drawing, you have to press the send button, pressing enter will not send the image.

--- a/index.js
+++ b/index.js
@@ -83,6 +83,16 @@ async function servePage(filename, res, type, textToReplace, replacement) { // t
   })
 }
 
+async function senddrawingAsync(req, res, body) {
+  const discordID = await auth.checkAuth(req, res)
+  // console.log("senddrawingAsync")
+  const urlQuery = url.parse("/?"+body, true).query
+  // console.log(urlQuery)
+  if (discordID) {
+    await senddrawing.sendDrawing(bot, req, res, [], discordID, urlQuery)
+  }
+}
+
 server.on('request', async (req, res) => {
   if (req.method === 'POST') {
     let body = '' // https://itnext.io/how-to-handle-the-post-request-body-in-node-js-without-using-a-framework-cd2038b93190
@@ -95,6 +105,13 @@ server.on('request', async (req, res) => {
         toggleTheme(req, res)
       } else if (parsedurl == "/toggleImages") {
         toggleImages(req, res)
+      }else if (parsedurl == "/senddrawing") {
+        senddrawingAsync(req, res, body).then(() => {}).catch((err) => {
+          console.log(err)
+          res.writeHead(500, { 'Content-Type': 'text/plain' })
+          res.end('Internal Server Error')
+        }
+        )
       } else {
         auth.handleLoginRegister(req, res, body)
       }
@@ -108,13 +125,9 @@ server.on('request', async (req, res) => {
       if (discordID) {
         await sendpage.sendMessage(bot, req, res, args, discordID)
       }
-    } else if (args[1] === 'senddrawing') {
-      const discordID = await auth.checkAuth(req, res)
-      if (discordID) {
-        console.log("senddrawing")
-        await senddrawing.sendDrawing(bot, req, res, args, discordID)
-      }
-    } else if (args[1] === 'reply') {
+    } else if (args[1] === 'senddrawing') {}
+    
+    else if (args[1] === 'reply') {
       const discordID = await auth.checkAuth(req, res)
       if (discordID) {
         await replypage.replyMessage(bot, req, res, args, discordID)

--- a/pages/reply.js
+++ b/pages/reply.js
@@ -20,7 +20,7 @@ async function clean(server, nodelete) {
 async function getOrCreateWebhook(channel, guildID) {
   try {
     const existingWebhooks = await channel.fetchWebhooks();
-    let webhook = existingWebhooks.find(w => w.owner.username === "Discross");
+    let webhook = existingWebhooks.find(w => w.owner.username === "discross beta" || w.owner.username === "Discross");
 
     if (!webhook) {
       webhook = await channel.createWebhook({

--- a/pages/send.js
+++ b/pages/send.js
@@ -20,7 +20,7 @@ async function clean(server, nodelete) {
 async function getOrCreateWebhook(channel, guildID) {
   try {
     const existingWebhooks = await channel.fetchWebhooks();
-    let webhook = existingWebhooks.find(w => w.owner.username === "Discross");
+    let webhook = existingWebhooks.find(w => w.owner.username === "discross beta" || w.owner.username === "Discross");
 
     if (!webhook) {
       webhook = await channel.createWebhook({

--- a/pages/templates/draw.html
+++ b/pages/templates/draw.html
@@ -218,7 +218,7 @@
 
                         </div>
                         <a id="end" name="end"></a>
-                        <form action="../senddrawing">
+                        <form action="../senddrawing" method="post">
                             <table>
                                 <tbody>
                                     <tr>
@@ -261,8 +261,8 @@
     </div>
     <script>
         var canvas = document.getElementById("sketchpad");
-        canvas.width = Math.min(window.innerWidth - 34 - 15, 400);
-        canvas.height = Math.min(window.innerHeight - 107.2 - 15, 200);
+        canvas.width = Math.min(window.innerWidth - 34 - 15, 1000);
+        canvas.height = Math.min(window.innerHeight - 107.2 - 15, 1000);
         var send = document.getElementById("send");
         var fakesend = document.getElementById("fakesend");
         var drawinginput = document.getElementById("drawinginput");


### PR DESCRIPTION
Change Log
- made drawing send use post instead of url args, fixes url max length
- made canvas max size 1000x1000

Known Issues
- On modern browsers, when drawing, you have to press the send button, pressing enter will not send the image.

## Summary by Sourcery

Addresses an issue where drawing functionality was limited by URL length restrictions by switching to POST requests. It also increases the maximum canvas size to 1000x1000.

Bug Fixes:
- Fixes an issue where the length of the URL was too long when sending drawings.
- Fixes issue where webhooks were not found if the bot's username was 'discross beta'

Enhancements:
- Increases the maximum canvas size to 1000x1000.