### PR TITLE
Revert "Fix button styling, emoji rendering in no-image mode, and remove HTML minification"

### DIFF
--- a/pages/channel.js
+++ b/pages/channel.js
@@ -1,4 +1,6 @@
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 var md = require('markdown-it')({ breaks: true, linkify: true });
 var he = require('he'); // Encodes HTML attributes
@@ -10,21 +12,24 @@ const { PermissionFlagsBits } = require('discord.js');
 const { channel } = require('diagnostics_channel');
 // const { console } = require('inspector'); // sorry idk why i added this
 const fetch = require("sync-fetch");
+// Minify at runtime to save data on slow connections, but still allow editing the unminified file easily
+// Is that a bad idea?
+
 // Templates for viewing the messages in a channel
-const channel_template = fs.readFileSync('pages/templates/channel.html', 'utf-8');
+const channel_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel.html', 'utf-8'));
 
 
-const message_template = fs.readFileSync('pages/templates/message/message.html', 'utf-8');
-const first_message_content_template = fs.readFileSync('pages/templates/message/first_message_content.html', 'utf-8');
-const merged_message_content_template = fs.readFileSync('pages/templates/message/merged_message_content.html', 'utf-8');
-const mention_template = fs.readFileSync('pages/templates/message/mention.html', 'utf-8');
+const message_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/message.html', 'utf-8'));
+const first_message_content_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/first_message_content.html', 'utf-8'));
+const merged_message_content_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/merged_message_content.html', 'utf-8'));
+const mention_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/mention.html', 'utf-8'));
 
-const input_template = fs.readFileSync('pages/templates/channel/input.html', 'utf-8');
-const input_disabled_template = fs.readFileSync('pages/templates/channel/input_disabled.html', 'utf-8');
+const input_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/input.html', 'utf-8'));
+const input_disabled_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/input_disabled.html', 'utf-8'));
 
-const no_message_history_template = fs.readFileSync('pages/templates/channel/no_message_history.html', 'utf-8');
+const no_message_history_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/no_message_history.html', 'utf-8'));
 
-const file_download_template = fs.readFileSync('pages/templates/channel/file_download.html', 'utf-8');
+const file_download_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/file_download.html', 'utf-8'));
 
 function strReplace(string, needle, replacement) {
   return string.split(needle).join(replacement || "");
@@ -269,7 +274,7 @@ exports.processChannel = async function processChannel(bot, req, res, args, disc
         final = strReplace(template, "{$INPUT}", input_disabled_template);
       }
 
-      if (response.match?.(emojiRegex) && imagesCookie === "1") {
+      if (response.match?.(emojiRegex) && imagesCookie == 1) {
         const unicode_emoji_matches = [...response.match?.(emojiRegex)]
         unicode_emoji_matches.forEach(match => {
           const points = [];
@@ -294,7 +299,7 @@ exports.processChannel = async function processChannel(bot, req, res, args, disc
       }
 
       const custom_emoji_matches = [...response.matchAll?.(/&lt;(:)?(?:(a):)?(\w{2,32}):(\d{17,19})?(?:(?!\1).)*&gt;?/g)];                // I'm not sure how to detect if an emoji is inline, since we don't have the whole message here to use it's length.
-      if (custom_emoji_matches[0] && imagesCookie === "1") custom_emoji_matches.forEach(async match => {                                                          // Tried Regex to find the whole message by matching the HTML tags that would appear before and after a message
+      if (custom_emoji_matches[0] && imagesCookie) custom_emoji_matches.forEach(async match => {                                                          // Tried Regex to find the whole message by matching the HTML tags that would appear before and after a message
         response = response.replace(match[0], `<img src="/imageProxy/emoji/${match[4]}.${match[2] ? "gif" : "png"}" style="width: 3%;"  alt="emoji">`)    // Make it smaller if inline
       })
       const randomEmoji = ["1f62d", "1f480", "2764-fe0f", "1f44d", "1f64f", "1f389", "1f642"][Math.floor(Math.random() * 7)];

--- a/pages/channel_reply.js
+++ b/pages/channel_reply.js
@@ -1,4 +1,6 @@
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 var md = require('markdown-it')({ breaks: true, linkify: true });
 var he = require('he'); // Encodes HTML attributes
@@ -9,24 +11,27 @@ const sanitizer = require("path-sanitizer");
 const { PermissionFlagsBits } = require('discord.js');
 const fetch = require("sync-fetch");
 
+// Minify at runtime to save data on slow connections, but still allow editing the unminified file easily
+// Is that a bad idea?
+
 // Templates for viewing the messages in a channel
-// const channel_template = fs.readFileSync('pages/templates/channel.html', 'utf-8');
-const channel_template = fs.readFileSync('pages/templates/channel_reply.html', 'utf-8');
+// const channel_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel.html', 'utf-8'));
+const channel_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel_reply.html', 'utf-8'));
 
 
-const message_template = fs.readFileSync('pages/templates/message/message_reply.html', 'utf-8');
-const first_message_content_template = fs.readFileSync('pages/templates/message/first_message_content.html', 'utf-8');
-const merged_message_content_template = fs.readFileSync('pages/templates/message/merged_message_content.html', 'utf-8');
-const first_message_content_large_emoji_template = fs.readFileSync('pages/templates/message/first_message_content_large_emoji.html', 'utf-8');
-const merged_message_content_large_emoji_template = fs.readFileSync('pages/templates/message/merged_message_content_large_emoji.html', 'utf-8');
-const mention_template = fs.readFileSync('pages/templates/message/mention.html', 'utf-8');
+const message_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/message_reply.html', 'utf-8'));
+const first_message_content_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/first_message_content.html', 'utf-8'));
+const merged_message_content_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/merged_message_content.html', 'utf-8'));
+const first_message_content_large_emoji_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/first_message_content_large_emoji.html', 'utf-8'));
+const merged_message_content_large_emoji_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/merged_message_content_large_emoji.html', 'utf-8'));
+const mention_template = minifier.htmlMinify(fs.readFileSync('pages/templates/message/mention.html', 'utf-8'));
 
-const input_template = fs.readFileSync('pages/templates/channel/input.html', 'utf-8');
-const input_disabled_template = fs.readFileSync('pages/templates/channel/input_disabled.html', 'utf-8');
+const input_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/input.html', 'utf-8'));
+const input_disabled_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/input_disabled.html', 'utf-8'));
 
-const no_message_history_template = fs.readFileSync('pages/templates/channel/no_message_history.html', 'utf-8');
+const no_message_history_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/no_message_history.html', 'utf-8'));
 
-const file_download_template = fs.readFileSync('pages/templates/channel/file_download.html', 'utf-8');
+const file_download_template = minifier.htmlMinify(fs.readFileSync('pages/templates/channel/file_download.html', 'utf-8'));
 
 function strReplace(string, needle, replacement) {
   return string.split(needle).join(replacement || "");
@@ -299,7 +304,7 @@ exports.processChannelReply = async function processChannelReply(bot, req, res, 
         final = strReplace(template, "{$INPUT}", input_disabled_template);
       }
 
-      if (response.match?.(emojiRegex) && imagesCookie === "1") {
+      if (response.match?.(emojiRegex) && imagesCookie == 1) {
         const unicode_emoji_matches = [...response.match?.(emojiRegex)]
         unicode_emoji_matches.forEach(match => {
           const points = [];
@@ -324,7 +329,7 @@ exports.processChannelReply = async function processChannelReply(bot, req, res, 
       }
 
       const custom_emoji_matches = [...response.matchAll?.(/&lt;(:)?(?:(a):)?(\w{2,32}):(\d{17,19})?(?:(?!\1).)*&gt;?/g)];                // I'm not sure how to detect if an emoji is inline, since we don't have the whole message here to use it's length.
-      if (custom_emoji_matches[0] && imagesCookie === "1") custom_emoji_matches.forEach(async match => {                                                          // Tried Regex to find the whole message by matching the HTML tags that would appear before and after a message
+      if (custom_emoji_matches[0] && imagesCookie) custom_emoji_matches.forEach(async match => {                                                          // Tried Regex to find the whole message by matching the HTML tags that would appear before and after a message
         response = response.replace(match[0], `<img src="/imageProxy/emoji/${match[4]}.${match[2] ? "gif" : "png"}" style="width: 3%;"  alt="emoji">`)    // Make it smaller if inline
       })
       let reply_message_id = args[3];

--- a/pages/draw.js
+++ b/pages/draw.js
@@ -1,4 +1,6 @@
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 var md = require('markdown-it')({ breaks: true, linkify: true });
 var he = require('he'); // Encodes HTML attributes

--- a/pages/forgot.js
+++ b/pages/forgot.js
@@ -1,11 +1,13 @@
 var url = require('url');
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 
 var auth = require('../authentication.js');
 
-const forgot_template = fs.readFileSync('pages/templates/forgot.html', 'utf-8');
-const error_template = fs.readFileSync('pages/templates/login/error.html', 'utf-8');
+const forgot_template = minifier.htmlMinify(fs.readFileSync('pages/templates/forgot.html', 'utf-8'));
+const error_template = minifier.htmlMinify(fs.readFileSync('pages/templates/login/error.html', 'utf-8'));
 
 function strReplace(string, needle, replacement) {
   return string.split(needle).join(replacement || "");

--- a/pages/guest.js
+++ b/pages/guest.js
@@ -1,11 +1,13 @@
 /*var url = require('url');
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 
 var auth = require('../authentication.js');
 
-const guest_login_template = fs.readFileSync('pages/templates/guest.html', 'utf-8');
-const error_template = fs.readFileSync('pages/templates/login/error.html', 'utf-8');
+const guest_login_template = minifier.htmlMinify(fs.readFileSync('pages/templates/guest.html', 'utf-8'));
+const error_template = minifier.htmlMinify(fs.readFileSync('pages/templates/login/error.html', 'utf-8'));
 
 function strReplace(string, needle, replacement) {
   return string.split(needle).join(replacement || "");

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,14 @@
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 
 var auth = require('../authentication.js');
 
-const index_template = fs.readFileSync('pages/templates/index.html', 'utf-8');
+const index_template = minifier.htmlMinify(fs.readFileSync('pages/templates/index.html', 'utf-8'));
 
-const logged_in_template = fs.readFileSync('pages/templates/index/logged_in.html', 'utf-8');
-const logged_out_template = fs.readFileSync('pages/templates/index/logged_out.html', 'utf-8');
+const logged_in_template = minifier.htmlMinify(fs.readFileSync('pages/templates/index/logged_in.html', 'utf-8'));
+const logged_out_template = minifier.htmlMinify(fs.readFileSync('pages/templates/index/logged_out.html', 'utf-8'));
 
 function strReplace(string, needle, replacement) {
   return string.split(needle).join(replacement || "");

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,11 +1,13 @@
 var url = require('url');
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 
 var auth = require('../authentication.js');
 
-const login_template = fs.readFileSync('pages/templates/login.html', 'utf-8');
-const error_template = fs.readFileSync('pages/templates/login/error.html', 'utf-8');
+const login_template = minifier.htmlMinify(fs.readFileSync('pages/templates/login.html', 'utf-8'));
+const error_template = minifier.htmlMinify(fs.readFileSync('pages/templates/login/error.html', 'utf-8'));
 
 function strReplace(string, needle, replacement) {
   return string.split(needle).join(replacement || "");

--- a/pages/register.js
+++ b/pages/register.js
@@ -1,11 +1,13 @@
 var url = require('url');
 var fs = require('fs');
+var HTMLMinifier = require('@bhavingajjar/html-minify');
+var minifier = new HTMLMinifier();
 var escape = require('escape-html');
 
 var auth = require('../authentication.js');
 
-const register_template = fs.readFileSync('pages/templates/register.html', 'utf-8');
-const error_template = fs.readFileSync('pages/templates/login/error.html', 'utf-8');
+const register_template = minifier.htmlMinify(fs.readFileSync('pages/templates/register.html', 'utf-8'));
+const error_template = minifier.htmlMinify(fs.readFileSync('pages/templates/login/error.html', 'utf-8'));
 
 function strReplace(string, needle, replacement) {
   return string.split(needle).join(replacement || "");

--- a/pages/templates/channel.html
+++ b/pages/templates/channel.html
@@ -185,24 +185,6 @@
             color: #5865f2 !important;
         }
 
-        /* Exception for purple send buttons in AMOLED theme */
-        .amoled-theme .send-button,
-        .amoled-theme .btn-send,
-        .amoled-theme button.send,
-        .amoled-theme .chat-send {
-            background: #5865f2 !important;
-            color: #ffffff !important;
-        }
-
-        /* Exception for purple send buttons in light theme */
-        .light-theme .send-button,
-        .light-theme .btn-send,
-        .light-theme button.send,
-        .light-theme .chat-send {
-            background: #5865f2 !important;
-            color: #ffffff !important;
-        }
-
         .message:hover {
             background: rgba(4, 4, 5, 0.07);
         }

--- a/pages/templates/channel_reply.html
+++ b/pages/templates/channel_reply.html
@@ -185,24 +185,6 @@
             color: #5865f2 !important;
         }
 
-        /* Exception for purple send buttons in AMOLED theme */
-        .amoled-theme .send-button,
-        .amoled-theme .btn-send,
-        .amoled-theme button.send,
-        .amoled-theme .chat-send {
-            background: #5865f2 !important;
-            color: #ffffff !important;
-        }
-
-        /* Exception for purple send buttons in light theme */
-        .light-theme .send-button,
-        .light-theme .btn-send,
-        .light-theme button.send,
-        .light-theme .chat-send {
-            background: #5865f2 !important;
-            color: #ffffff !important;
-        }
-
         .message:hover {
             background: rgba(4, 4, 5, 0.07);
         }

--- a/pages/templates/draw.html
+++ b/pages/templates/draw.html
@@ -107,24 +107,6 @@
             color: #5865f2 !important;
         }
 
-        /* Exception for purple send buttons in AMOLED theme */
-        .amoled-theme .send-button,
-        .amoled-theme .btn-send,
-        .amoled-theme button.send,
-        .amoled-theme .chat-send {
-            background: #5865f2 !important;
-            color: #ffffff !important;
-        }
-
-        /* Exception for purple send buttons in light theme */
-        .light-theme .send-button,
-        .light-theme .btn-send,
-        .light-theme button.send,
-        .light-theme .chat-send {
-            background: #5865f2 !important;
-            color: #ffffff !important;
-        }
-
         .message:hover {
             background: rgba(4, 4, 5, 0.07);
         }

--- a/pages/templates/forgot.html
+++ b/pages/templates/forgot.html
@@ -43,12 +43,8 @@
     .light-theme #wrapper * {
       background: #FFFFFF !important;
       color: #000000 !important;
-    }
-
-    /* Exception for purple buttons in light theme */
-    .light-theme input[type="submit"] {
-      background: #5865f2 !important;
-      color: #ffffff !important;
+      
+      
     }
 
     .light-theme #wrapper table input {
@@ -84,12 +80,6 @@
     .amoled-theme a {
       color: #5865f2 !important;
     }
-
-    /* Exception for purple buttons in AMOLED theme */
-    .amoled-theme input[type="submit"] {
-      background: #5865f2 !important;
-      color: #ffffff !important;
-    }
   </style>
   <title>Discross - Forgot username or password</title>
 </head>
@@ -123,6 +113,7 @@
       </tr>
     </table>
     <hr style="margin: 0; position: relative; bottom: 4px;">
+    <br>
     <table>
       <tbody>
         <tr>

--- a/pages/templates/index.html
+++ b/pages/templates/index.html
@@ -93,6 +93,15 @@
       background: #4752c4 !important;
     }
 
+    .light-theme .discross-button.secondary {
+      background: #4f545c !important;
+      color: white !important;
+    }
+
+    .light-theme .discross-button.secondary:hover {
+      background: #5d6269 !important;
+    }
+
     /* AMOLED theme */
     .amoled-theme #wrapper {
       background: #000000 !important;
@@ -102,11 +111,6 @@
     .amoled-theme #wrapper * {
       background: #000000 !important;
       color: #ffffff !important;
-    }
-
-    .amoled-theme .discross-button {
-      background: #5865f2 !important;
-      color: white !important;
     }
 
     .amoled-theme a {

--- a/pages/templates/login.html
+++ b/pages/templates/login.html
@@ -43,12 +43,8 @@
     .light-theme #wrapper * {
       background: #FFFFFF !important;
       color: #000000 !important;
-    }
-
-    /* Exception for purple buttons in light theme */
-    .light-theme input[type="submit"] {
-      background: #5865f2 !important;
-      color: #ffffff !important;
+      
+      
     }
 
     .light-theme #wrapper table div {
@@ -89,12 +85,6 @@
     .amoled-theme a {
       color: #5865f2 !important;
     }
-
-    /* Exception for purple buttons in AMOLED theme */
-    .amoled-theme input[type="submit"] {
-      background: #5865f2 !important;
-      color: #ffffff !important;
-    }
   </style>
   <title>Discross - Login</title>
 </head>
@@ -128,6 +118,7 @@
       </tr>
     </table>
     <hr style="margin: 0; position: relative; bottom: 4px;">
+    <br>
     <table>
       <tbody>
         <tr>

--- a/pages/templates/register.html
+++ b/pages/templates/register.html
@@ -45,12 +45,6 @@
       color: #000000 !important;
     }
 
-    /* Exception for purple buttons in light theme */
-    .light-theme input[type="submit"] {
-      background: #5865f2 !important;
-      color: #ffffff !important;
-    }
-
     .light-theme #wrapper table input {
       border: 5px solid #000000 !important;
       padding: 5px;
@@ -76,12 +70,6 @@
 
     .amoled-theme a {
       color: #5865f2 !important;
-    }
-
-    /* Exception for purple buttons in AMOLED theme */
-    .amoled-theme input[type="submit"] {
-      background: #5865f2 !important;
-      color: #ffffff !important;
     }
     }
   </style>
@@ -117,6 +105,7 @@
       </tr>
     </table>
     <hr style="margin: 0; position: relative; bottom: 4px;">
+    <br>
     <table>
       <tbody>
         <tr>

--- a/pages/templates/server/no_images_warning.html
+++ b/pages/templates/server/no_images_warning.html
@@ -14,18 +14,6 @@
       transition: background-color 0.2s ease;
       margin: 8px 0;
     }
-
-    /* Exception for purple buttons in light theme */
-    .light-theme .discross-button {
-      background: #5865f2 !important;
-      color: white !important;
-    }
-
-    /* Exception for purple buttons in AMOLED theme */
-    .amoled-theme .discross-button {
-      background: #5865f2 !important;
-      color: white !important;
-    }
 </style>
 <font face="'rodin', Arial, Helvetica, sans-serif" color="#dddddd">
 All images are currently turned OFF

--- a/pages/templates/server/server_list_only.html
+++ b/pages/templates/server/server_list_only.html
@@ -14,18 +14,6 @@
       transition: background-color 0.2s ease;
       margin: 8px 0;
     }
-
-    /* Exception for purple buttons in light theme */
-    .light-theme .discross-button {
-      background: #5865f2 !important;
-      color: white !important;
-    }
-
-    /* Exception for purple buttons in AMOLED theme */
-    .amoled-theme .discross-button {
-      background: #5865f2 !important;
-      color: white !important;
-    }
 </style>
 <font face="'rodin', Arial, Helvetica, sans-serif" color="#dddddd">
   <font size="5" color="#5865f2"><b>Select a Server</b></font>

--- a/pages/templates/server/sync_warning.html
+++ b/pages/templates/server/sync_warning.html
@@ -14,18 +14,6 @@
       transition: background-color 0.2s ease;
       margin: 8px 0;
     }
-
-    /* Exception for purple buttons in light theme */
-    .light-theme .discross-button {
-      background: #5865f2 !important;
-      color: white !important;
-    }
-
-    /* Exception for purple buttons in AMOLED theme */
-    .amoled-theme .discross-button {
-      background: #5865f2 !important;
-      color: white !important;
-    }
 </style>
 <div
   style="background: #5865f2; border: 2px solid #4752c4; border-radius: 8px; padding: 20px; margin: 16px 0; text-align: center;">


### PR DESCRIPTION
Reverts larsenv/discross#129

## Summary by Sourcery

Reintroduce HTML minification for server, channel, index, auth, and drawing pages while adjusting theme-specific button styling and emoji rendering conditions.

Enhancements:
- Minify various HTML templates at runtime across channel, server, index, auth-related, and drawing pages to reduce payload size.
- Adjust theme-specific button and secondary button styling across multiple templates, including index and auth pages, for consistent appearance.
- Modify emoji rendering conditions to rely on numeric or truthy image preference flags instead of strict string comparison.